### PR TITLE
Pin actions to hashes using pinact [workflow-enforcer]

### DIFF
--- a/.github/workflows/reproducer.yml
+++ b/.github/workflows/reproducer.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Job
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - run: echo "$github"
         env:
           github: ${{ toJSON(github) }}
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Job
     steps:
-      - uses: actions/checkout@v4 
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - run: echo "$github"
         env:
           github: ${{ toJSON(github) }}
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Job
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - run: echo "$github"
         env:
           github: ${{ toJSON(github) }}


### PR DESCRIPTION
This PR pins action references to commit hashes to mitigate supply chain attacks where a bad actor will push a new tag or override an existing tag, leading to us running malicious code immediately without explicitly updating.

Documentation on how to use pinact can be found in the internal developers site.
